### PR TITLE
Added support for /*sql*/ as begin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Syntax highlighting for code like:
 
 ```js
 const query = sql`SELECT * FROM users`;
+
+//Or with comments so that javascript doesn't crash
+const query2 = /*sql*/`SELECT * FROM users`;
 ```
 
 ## Publishing

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-sql-template-literal",
     "displayName": "vscode-sql-template-literal",
     "description": "Syntax highlighting for sql in template literals",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "forbeslindesay",
     "license": "MIT",
     "repository": {

--- a/syntaxes/lit-sql.json
+++ b/syntaxes/lit-sql.json
@@ -5,7 +5,7 @@
     {
       "name": "taggedTemplates",
       "contentName": "meta.embedded.block.sql",
-      "begin": "sql((`))",
+      "begin": "(sql|\\/\\*sql\\*\\/)?`",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.tagged-template.js"

--- a/test.js
+++ b/test.js
@@ -1,1 +1,2 @@
 const query = sql`SELECT * FROM users`;
+const query2 = /*sql*/`SELECT * FROM users`;


### PR DESCRIPTION
I just expanded the begin extension a bit to support both sql` and /*sql*/`.

This is so that the sql syntax markup doesn't generate an error when you run your javascript app.